### PR TITLE
fix: macos support for deploy-postgres.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pass
 *.env
+**/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# TaylorBot secret files
 *.pass
 *.env
-**/.DS_Store
+
+# macOS
+.DS_Store

--- a/src/taylorbot-postgres/local/deploy-postgres.sh
+++ b/src/taylorbot-postgres/local/deploy-postgres.sh
@@ -27,10 +27,12 @@ docker container run \
     --publish 127.0.0.1:14487:5432/tcp \
     postgres:12
 
-sleep 10s
+echo "Waiting for database server to be ready..."
+sleep 20
 
 taylorbot_role_password=$(cat "${__dir}/taylorbot-role.pass")
 
+echo "Creating taylorbot role..."
 docker exec --interactive ${container_name} \
     psql --username=postgres --command="CREATE ROLE taylorbot WITH LOGIN PASSWORD '${taylorbot_role_password}';"
 docker exec --interactive ${container_name} \


### PR DESCRIPTION
The `deploy-postgres.sh` script in taylorbot-postgres uses `sleep` with a time quantifier. Unfortunately, macOS [does not support](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sleep.3.html) `sleep` with time quantifiers. However, we can get around this by simply removing the quantifier. This should not break support for Linux machine.

I also upped the time from 10 seconds to 20 seconds, as 10 seconds did not allow enough time for the database server to become ready, on my computer.

Small Change: added `DS_Store` to `.gitignore`. Those files are used by macOS for storing metadata about a directory and should be ignored by git.