### PR TITLE
enhance(modmail): Update modmail message-mods command to use modal interface

### DIFF
--- a/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Modmail/Commands/ModMailMessageModsSlashCommand.cs
+++ b/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Modmail/Commands/ModMailMessageModsSlashCommand.cs
@@ -11,22 +11,22 @@ using TaylorBot.Net.Core.Strings;
 
 namespace TaylorBot.Net.Commands.Discord.Program.Modules.Modmail.Commands;
 
+public record NoOptions; 
+
 public class ModMailMessageModsSlashCommand(
     ILogger<ModMailMessageModsSlashCommand> logger,
     IOptionsMonitor<ModMailOptions> options,
     IModMailBlockedUsersRepository modMailBlockedUsersRepository,
-    ModMailChannelLogger modMailChannelLogger) : ISlashCommand<ModMailMessageModsSlashCommand.Options>
+    ModMailChannelLogger modMailChannelLogger) : ISlashCommand<NoOptions>
 {
     public static string CommandName => "modmail message-mods";
 
     public ISlashCommandInfo Info => new ModalCommandInfo(CommandName);
 
-    public record Options();
-
     private static readonly Color EmbedColor = new(255, 255, 240);
     private readonly IOptionsMonitor<ModMailOptions> _options = options;
 
-    public ValueTask<Command> GetCommandAsync(RunContext context, Options options)
+    public ValueTask<Command> GetCommandAsync(RunContext context, NoOptions options)
     {
         return new(new Command(
             new(Info.Name),
@@ -40,7 +40,7 @@ public class ModMailMessageModsSlashCommand(
                     Id: "modmail-message-mods",
                     Title: "Send Message to Moderators",
                     TextInputs: [
-                        new TextInput(Id: "subject", Style: TextInputStyle.Short, Label: "Subject", Required: true, MaxLength: 100),
+                        new TextInput(Id: "subject", Style: TextInputStyle.Short, Label: "Subject", Required: false, MaxLength: 50),
                         new TextInput(Id: "messagecontent", Style: TextInputStyle.Paragraph, Label: "Message to moderators", Required: true)
                     ],
                     SubmitAction: SubmitAsync,
@@ -51,6 +51,11 @@ public class ModMailMessageModsSlashCommand(
                 ValueTask<MessageResult> SubmitAsync(ModalSubmit submit)
                 {
                     var subject = submit.TextInputs.Single(t => t.CustomId == "subject").Value;
+                    if (string.IsNullOrWhiteSpace(subject))
+                    {
+                        subject = "No Subject";
+                    }
+
                     var messageContent = submit.TextInputs.Single(t => t.CustomId == "messagecontent").Value;
 
                     // Creates an embed containing the user's message and metadata

--- a/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Modmail/Commands/ModMailMessageModsSlashCommand.cs
+++ b/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Modmail/Commands/ModMailMessageModsSlashCommand.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TaylorBot.Net.Commands.Discord.Program.Modules.Modmail.Domain;
 using TaylorBot.Net.Commands.Discord.Program.Options;
-using TaylorBot.Net.Commands.Parsers;
 using TaylorBot.Net.Commands.PostExecution;
 using TaylorBot.Net.Commands.Preconditions;
 using TaylorBot.Net.Core.Embed;
@@ -20,9 +19,9 @@ public class ModMailMessageModsSlashCommand(
 {
     public static string CommandName => "modmail message-mods";
 
-    public ISlashCommandInfo Info => new MessageCommandInfo(CommandName, IsPrivateResponse: true);
+    public ISlashCommandInfo Info => new ModalCommandInfo(CommandName);
 
-    public record Options(ParsedString message);
+    public record Options();
 
     private static readonly Color EmbedColor = new(255, 255, 240);
     private readonly IOptionsMonitor<ModMailOptions> _options = options;
@@ -36,21 +35,42 @@ public class ModMailMessageModsSlashCommand(
                 var guild = context.Guild?.Fetched;
                 ArgumentNullException.ThrowIfNull(guild);
 
-                var embed = new EmbedBuilder()
-                    .WithColor(EmbedColor)
-                    .WithTitle("Message")
-                    .WithDescription(options.message.Value)
-                    .AddField("From", context.User.FormatTagAndMention(), inline: true)
-                    .WithFooter("Mod mail received", iconUrl: _options.CurrentValue.ReceivedLogEmbedFooterIconUrl)
-                    .WithCurrentTimestamp()
-                .Build();
-
-                return new(MessageResult.CreatePrompt(
-                    new(new[] { embed, EmbedFactory.CreateWarning($"Are you sure you want to send the above message to the moderation team of '{guild.Name}'?") }),
-                    confirm: async () => new(await SendAsync())
+                // Creates a modal form with subject and message fields for users to compose their message
+                return new(new CreateModalResult(
+                    Id: "modmail-message-mods",
+                    Title: "Send Message to Moderators",
+                    TextInputs: [
+                        new TextInput(Id: "subject", Style: TextInputStyle.Short, Label: "Subject", Required: true, MaxLength: 100),
+                        new TextInput(Id: "messagecontent", Style: TextInputStyle.Paragraph, Label: "Message to moderators", Required: true)
+                    ],
+                    SubmitAction: SubmitAsync,
+                    IsPrivateResponse: true
                 ));
 
-                async ValueTask<Embed> SendAsync()
+                // Processes the submitted message and shows a confirmation prompt
+                ValueTask<MessageResult> SubmitAsync(ModalSubmit submit)
+                {
+                    var subject = submit.TextInputs.Single(t => t.CustomId == "subject").Value;
+                    var messageContent = submit.TextInputs.Single(t => t.CustomId == "messagecontent").Value;
+
+                    // Creates an embed containing the user's message and metadata
+                    var embed = new EmbedBuilder()
+                        .WithColor(EmbedColor)
+                        .WithTitle(subject)
+                        .WithDescription(messageContent)
+                        .AddField("From", context.User.FormatTagAndMention(), inline: true)
+                        .WithFooter("Mod mail received", iconUrl: _options.CurrentValue.ReceivedLogEmbedFooterIconUrl)
+                        .WithCurrentTimestamp()
+                        .Build();
+
+                    return new(MessageResult.CreatePrompt(
+                        new(new[] { embed, EmbedFactory.CreateWarning($"Are you sure you want to send the above message to the moderation team of '{guild.Name}'?") }),
+                        confirm: async () => new(await SendAsync(embed))
+                    ));
+                }
+
+                // Handles message delivery to the moderation team's channel
+                async ValueTask<Embed> SendAsync(Embed embed)
                 {
                     var isBlocked = await modMailBlockedUsersRepository.IsBlockedAsync(guild, context.User);
                     if (isBlocked)

--- a/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Modmail/Commands/ModMailMessageModsSlashCommand.cs
+++ b/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Modmail/Commands/ModMailMessageModsSlashCommand.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TaylorBot.Net.Commands.Discord.Program.Modules.Modmail.Domain;
 using TaylorBot.Net.Commands.Discord.Program.Options;
+using TaylorBot.Net.Commands.Parsers;
 using TaylorBot.Net.Commands.PostExecution;
 using TaylorBot.Net.Commands.Preconditions;
 using TaylorBot.Net.Core.Embed;
@@ -10,8 +11,6 @@ using TaylorBot.Net.Core.Logging;
 using TaylorBot.Net.Core.Strings;
 
 namespace TaylorBot.Net.Commands.Discord.Program.Modules.Modmail.Commands;
-
-public record NoOptions; 
 
 public class ModMailMessageModsSlashCommand(
     ILogger<ModMailMessageModsSlashCommand> logger,
@@ -26,7 +25,7 @@ public class ModMailMessageModsSlashCommand(
     private static readonly Color EmbedColor = new(255, 255, 240);
     private readonly IOptionsMonitor<ModMailOptions> _options = options;
 
-    public ValueTask<Command> GetCommandAsync(RunContext context, NoOptions options)
+    public ValueTask<Command> GetCommandAsync(RunContext context, NoOptions _)
     {
         return new(new Command(
             new(Info.Name),

--- a/src/slash-commands/modmail.json
+++ b/src/slash-commands/modmail.json
@@ -10,7 +10,7 @@
   "options": [
     {
       "name": "message-mods",
-      "description": "As a user, send a message to a server's moderation team",
+      "description": "Send a message to this server's moderation team (a window will open to type your message)",
       "type": 1
     },
     {

--- a/src/slash-commands/modmail.json
+++ b/src/slash-commands/modmail.json
@@ -11,15 +11,7 @@
     {
       "name": "message-mods",
       "description": "As a user, send a message to a server's moderation team",
-      "type": 1,
-      "options": [
-        {
-          "name": "message",
-          "description": "The message to send",
-          "type": 3,
-          "required": true
-        }
-      ]
+      "type": 1
     },
     {
       "name": "message-user",


### PR DESCRIPTION
This PR updates the modmail message-mods slash command to improve user interaction and message delivery:
- Replaced the old workflow with a modal for subject and message input.
- Enabled users to compose and submit messages directly through the modal.