### PR TITLE
feat: Added handling for percentage input in Taypoint balance parsing

### DIFF
--- a/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Taypoints/Domain/ITaypointBalanceRepository.cs
+++ b/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Taypoints/Domain/ITaypointBalanceRepository.cs
@@ -84,9 +84,6 @@ public class TaypointAmountParser(StringParser stringParser, ITaypointBalanceRep
             case "25%":
                 return new RelativeTaypointAmount(4);
 
-            case "33%":
-                return new RelativeTaypointAmount(3);
-
             case "50%":
                 return new RelativeTaypointAmount(2);
 
@@ -114,7 +111,7 @@ public class TaypointAmountParser(StringParser stringParser, ITaypointBalanceRep
                 }
                 else
                 {
-                    return Error(new ParsingFailed("Must be a valid number or fraction ('all', 'half' or 'third')."));
+                    return Error(new ParsingFailed("Must be a valid number, fraction ('all', 'half' or 'third') or special percent (1%,2%,4%,5%,10%,20%,25%,50%,100%)."));
                 }
         }
     }

--- a/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Taypoints/Domain/ITaypointBalanceRepository.cs
+++ b/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Taypoints/Domain/ITaypointBalanceRepository.cs
@@ -62,27 +62,42 @@ public class TaypointAmountParser(StringParser stringParser, ITaypointBalanceRep
             case "FOURTH":
                 return new RelativeTaypointAmount(4);
 
+            // TODO: Find a long-term solution for percentages
+            case "1%":
+                return new RelativeTaypointAmount(100);
+
+            case "2%":
+                return new RelativeTaypointAmount(50);
+
+            case "4%":
+                return new RelativeTaypointAmount(25);
+
+            case "5%":
+                return new RelativeTaypointAmount(20);
+
+            case "10%":
+                return new RelativeTaypointAmount(10);
+
+            case "20%":
+                return new RelativeTaypointAmount(5);
+
+            case "25%":
+                return new RelativeTaypointAmount(4);
+
+            case "33%":
+                return new RelativeTaypointAmount(3);
+
+            case "50%":
+                return new RelativeTaypointAmount(2);
+
+            case "100%":
+                return new RelativeTaypointAmount(1);
+
             default:
-                var inPercent = text.EndsWith("%");
-                if (inPercent)
-                {
-                    text = text.Substring(0, text.Length - 1);
-                }
-                
                 if (long.TryParse(text, out var amount))
                 {
                     if (amount > 0)
                     {
-                        if (inPercent)
-                        {
-                            if (amount > 100)
-                            {
-                                return Error(new ParsingFailed($"You can't spend more than you have (100%). 😕"));
-                            }
-                            
-                            return new RelativeTaypointAmount(100 / amount);
-                        };
-                        
                         var balance = await taypointBalanceRepository.GetBalanceAsync(context.User);
 
                         if (amount > balance)

--- a/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Taypoints/Domain/ITaypointBalanceRepository.cs
+++ b/src/TaylorBot.Net/Program.Commands.Discord/src/TaylorBot.Net.Commands.Discord.Program/Modules/Taypoints/Domain/ITaypointBalanceRepository.cs
@@ -63,10 +63,26 @@ public class TaypointAmountParser(StringParser stringParser, ITaypointBalanceRep
                 return new RelativeTaypointAmount(4);
 
             default:
+                var inPercent = text.EndsWith("%");
+                if (inPercent)
+                {
+                    text = text.Substring(0, text.Length - 1);
+                }
+                
                 if (long.TryParse(text, out var amount))
                 {
                     if (amount > 0)
                     {
+                        if (inPercent)
+                        {
+                            if (amount > 100)
+                            {
+                                return Error(new ParsingFailed($"You can't spend more than you have (100%). 😕"));
+                            }
+                            
+                            return new RelativeTaypointAmount(100 / amount);
+                        };
+                        
                         var balance = await taypointBalanceRepository.GetBalanceAsync(context.User);
 
                         if (amount > balance)


### PR DESCRIPTION
I've added percentage input to Taypoint parsing, allowing for commands like `/risk play 10%` or `!gamble 100%`.

You cannot go over 100% and not below 0%, so everything stays safe.